### PR TITLE
✨ ci: pass POSTGRES_URL to Vercel deploy workflow

### DIFF
--- a/.github/workflows/deploy-vercel.yml
+++ b/.github/workflows/deploy-vercel.yml
@@ -78,6 +78,7 @@ jobs:
         id: generate-vercel-project
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          POSTGRES_URL: ${{ secrets.POSTGRES_URL }}
         run: |
           # If a matching project already exists, reuse it; otherwise create a new project
           EXISTING_PROJECT_ID="${{ steps.cleanup-projects.outputs.existing_project_id }}"


### PR DESCRIPTION
Add POSTGRES_URL environment variable to the generate-vercel-project
step in the deploy-vercel GitHub Actions workflow. This ensures the
workflow exposes the database connection string (from repository
secrets) to deployment steps that require it, preventing runtime
errors when the app expects POSTGRES_URL during project generation or
build on Vercel.