### PR TITLE
✨ feat(ci): add Clerk vars to Vercel deploy workflow

### DIFF
--- a/.github/workflows/deploy-vercel.yml
+++ b/.github/workflows/deploy-vercel.yml
@@ -79,6 +79,8 @@ jobs:
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           POSTGRES_URL: ${{ secrets.POSTGRES_URL }}
+          NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: ${{ secrets.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY }}
+          CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
         run: |
           # If a matching project already exists, reuse it; otherwise create a new project
           EXISTING_PROJECT_ID="${{ steps.cleanup-projects.outputs.existing_project_id }}"


### PR DESCRIPTION
Add NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY and CLERK_SECRET_KEY to the
Vercel deployment job environment so the app receives Clerk credentials
during CI deploys.

This enables server and client code to access authentication keys when
creating or reusing Vercel projects in the workflow, preventing runtime
errors caused by missing Clerk configuration and ensuring auth-related
features work after automated deployments.