### PR TITLE
✨ feat: add resume fields, validation, list changes & cleanup script

### DIFF
--- a/drizzle/0002_add_structured_work_history_fields.sql
+++ b/drizzle/0002_add_structured_work_history_fields.sql
@@ -1,0 +1,17 @@
+-- Add new columns to work_history table
+ALTER TABLE "work_history" ADD COLUMN "company_name" text;
+ALTER TABLE "work_history" ADD COLUMN "role" text;
+ALTER TABLE "work_history" ADD COLUMN "date_of_work" text;
+ALTER TABLE "work_history" ADD COLUMN "description" text;
+
+-- Make content nullable as we're replacing it with structured fields
+ALTER TABLE "work_history" ALTER COLUMN "content" DROP NOT NULL;
+
+-- Backfill empty values for existing rows (if any)
+UPDATE "work_history" SET "company_name" = '', "role" = '', "date_of_work" = '', "description" = '' WHERE "company_name" IS NULL;
+
+-- Set new columns as NOT NULL
+ALTER TABLE "work_history" ALTER COLUMN "company_name" SET NOT NULL;
+ALTER TABLE "work_history" ALTER COLUMN "role" SET NOT NULL;
+ALTER TABLE "work_history" ALTER COLUMN "date_of_work" SET NOT NULL;
+ALTER TABLE "work_history" ALTER COLUMN "description" SET NOT NULL;

--- a/drizzle/0003_add_structured_project_fields.sql
+++ b/drizzle/0003_add_structured_project_fields.sql
@@ -1,0 +1,14 @@
+-- Add new columns to projects table
+ALTER TABLE "projects" ADD COLUMN "project_name" text;
+ALTER TABLE "projects" ADD COLUMN "project_url" text;
+ALTER TABLE "projects" ADD COLUMN "project_description" text;
+
+-- Make content nullable as we're replacing it with structured fields
+ALTER TABLE "projects" ALTER COLUMN "content" DROP NOT NULL;
+
+-- Backfill empty values for existing rows (if any)
+UPDATE "projects" SET "project_name" = '', "project_description" = '' WHERE "project_name" IS NULL;
+
+-- Set new columns as NOT NULL (except project_url which is optional)
+ALTER TABLE "projects" ALTER COLUMN "project_name" SET NOT NULL;
+ALTER TABLE "projects" ALTER COLUMN "project_description" SET NOT NULL;

--- a/drizzle/0004_add_structured_achievement_fields.sql
+++ b/drizzle/0004_add_structured_achievement_fields.sql
@@ -1,0 +1,14 @@
+-- Add new columns to achievements table
+ALTER TABLE "achievements" ADD COLUMN "achievement_name" text;
+ALTER TABLE "achievements" ADD COLUMN "achievement_url" text;
+ALTER TABLE "achievements" ADD COLUMN "achievement_description" text;
+
+-- Make content nullable as we're replacing it with structured fields
+ALTER TABLE "achievements" ALTER COLUMN "content" DROP NOT NULL;
+
+-- Backfill empty values for existing rows (if any)
+UPDATE "achievements" SET "achievement_name" = '', "achievement_description" = '' WHERE "achievement_name" IS NULL;
+
+-- Set new columns as NOT NULL (except achievement_url which is optional)
+ALTER TABLE "achievements" ALTER COLUMN "achievement_name" SET NOT NULL;
+ALTER TABLE "achievements" ALTER COLUMN "achievement_description" SET NOT NULL;

--- a/drizzle/0005_add_title_to_resumes.sql
+++ b/drizzle/0005_add_title_to_resumes.sql
@@ -1,0 +1,8 @@
+-- Add title column to resumes table
+ALTER TABLE "resumes" ADD COLUMN "title" text;
+
+-- Backfill existing rows with a default title
+UPDATE "resumes" SET "title" = 'My Resume' WHERE "title" IS NULL;
+
+-- Set title as NOT NULL
+ALTER TABLE "resumes" ALTER COLUMN "title" SET NOT NULL;

--- a/scripts/cleanup-database.ts
+++ b/scripts/cleanup-database.ts
@@ -1,0 +1,91 @@
+#!/usr/bin/env tsx
+import postgres from 'postgres';
+import 'dotenv/config';
+
+const DEFINED_TABLES = [
+  'resumes',
+  'work_history',
+  'projects',
+  'achievements',
+  '__drizzle_migrations',
+];
+
+// System tables to never drop
+const SYSTEM_TABLES = [
+  '__drizzle_migrations',
+];
+
+async function main() {
+  const connectionString = process.env.POSTGRES_URL;
+  if (!connectionString) {
+    console.error('❌ POSTGRES_URL environment variable is not set');
+    process.exit(1);
+  }
+
+  const sql = postgres(connectionString, { max: 1 });
+
+  try {
+    console.log('🔍 Checking database tables...\n');
+
+    // Get all tables in the public schema
+    const tables = await sql<{ tablename: string }[]>`
+      SELECT tablename 
+      FROM pg_tables 
+      WHERE schemaname = 'public'
+      ORDER BY tablename;
+    `;
+
+    console.log('📋 All tables in database:');
+    tables.forEach((t) => {
+      const status = DEFINED_TABLES.includes(t.tablename)
+        ? '✅ (defined in schema)'
+        : SYSTEM_TABLES.includes(t.tablename)
+        ? '🔧 (system table)'
+        : '⚠️  (NOT in schema)';
+      console.log(`  - ${t.tablename} ${status}`);
+    });
+
+    // Find tables to remove
+    const tablesToRemove = tables
+      .map((t) => t.tablename)
+      .filter((name) => !DEFINED_TABLES.includes(name) && !SYSTEM_TABLES.includes(name));
+
+    if (tablesToRemove.length === 0) {
+      console.log('\n✨ No extra tables found. Database is clean!');
+      await sql.end();
+      return;
+    }
+
+    console.log(`\n⚠️  Found ${tablesToRemove.length} table(s) not in schema:`);
+    tablesToRemove.forEach((name) => console.log(`  - ${name}`));
+
+    // Check if we should drop tables
+    const shouldDrop = process.argv.includes('--drop');
+
+    if (!shouldDrop) {
+      console.log('\n💡 To remove these tables, run:');
+      console.log('   pnpm tsx scripts/cleanup-database.ts --drop');
+      await sql.end();
+      return;
+    }
+
+    console.log('\n🗑️  Dropping tables...');
+    for (const tableName of tablesToRemove) {
+      try {
+        await sql.unsafe(`DROP TABLE IF EXISTS "${tableName}" CASCADE;`);
+        console.log(`  ✓ Dropped: ${tableName}`);
+      } catch (error: any) {
+        console.error(`  ✗ Failed to drop ${tableName}:`, error.message);
+      }
+    }
+
+    console.log('\n✅ Database cleanup complete!');
+  } catch (error) {
+    console.error('❌ Error:', error);
+    process.exit(1);
+  } finally {
+    await sql.end();
+  }
+}
+
+main();

--- a/src/app/api/resumes/[id]/route.ts
+++ b/src/app/api/resumes/[id]/route.ts
@@ -1,0 +1,35 @@
+import { auth } from '@clerk/nextjs/server';
+import { NextResponse } from 'next/server';
+import { getResume } from '@/lib/db/resume';
+
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { userId } = await auth();
+    if (!userId) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const { id } = await params;
+    const resume = await getResume(id);
+
+    if (!resume) {
+      return NextResponse.json({ error: 'Resume not found' }, { status: 404 });
+    }
+
+    // Verify the resume belongs to the requesting user
+    if (resume.userId !== userId) {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+    }
+
+    return NextResponse.json(resume);
+  } catch (error) {
+    console.error('Error fetching resume:', error);
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/resumes/page.tsx
+++ b/src/app/resumes/page.tsx
@@ -1,0 +1,122 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { SignedIn, SignedOut, SignInButton, UserButton } from '@clerk/nextjs';
+import Link from 'next/link';
+
+type Resume = {
+  id: string;
+  title: string;
+  name: string;
+  email: string;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export default function ResumesPage() {
+  const [resumes, setResumes] = useState<Resume[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    async function fetchResumes() {
+      try {
+        const res = await fetch('/api/resumes');
+        if (res.ok) {
+          const data = await res.json();
+          setResumes(data.resumes || []);
+        }
+      } catch (error) {
+        console.error('Failed to fetch resumes:', error);
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    fetchResumes();
+  }, []);
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-slate-50 to-blue-50 dark:from-slate-900 dark:to-slate-800 p-8">
+      <div className="max-w-6xl mx-auto">
+        <header className="flex items-center justify-between mb-12">
+          <div>
+            <h1 className="text-4xl font-bold text-slate-800 dark:text-slate-100 mb-1">
+              My Resumes
+            </h1>
+            <p className="text-lg text-slate-600 dark:text-slate-300">
+              Manage and edit your resume drafts
+            </p>
+          </div>
+          <div className="flex items-center gap-4">
+            <Link
+              href="/"
+              className="inline-flex items-center rounded-lg bg-sky-600 px-5 py-2 text-sm font-semibold text-white transition hover:bg-sky-700 focus:outline-none focus:ring-2 focus:ring-sky-400"
+            >
+              + New Resume
+            </Link>
+            <SignedIn>
+              <UserButton afterSignOutUrl="/" />
+            </SignedIn>
+          </div>
+        </header>
+
+        <SignedOut>
+          <section className="bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-xl shadow-lg p-8 text-center">
+            <h2 className="text-2xl font-semibold text-slate-800 dark:text-slate-100 mb-3">Sign in required</h2>
+            <p className="text-slate-600 dark:text-slate-300 mb-6">Please sign in to view your resumes.</p>
+            <SignInButton mode="modal">
+              <button className="inline-flex items-center rounded-lg bg-sky-600 px-5 py-2 text-sm font-semibold text-white transition hover:bg-sky-700 focus:outline-none focus:ring-2 focus:ring-sky-400">
+                Sign in to continue
+              </button>
+            </SignInButton>
+          </section>
+        </SignedOut>
+
+        <SignedIn>
+          {loading ? (
+            <div className="text-center py-12">
+              <p className="text-slate-500 dark:text-slate-400">Loading your resumes...</p>
+            </div>
+          ) : resumes.length === 0 ? (
+            <section className="bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-xl shadow-lg p-12 text-center">
+              <h2 className="text-2xl font-semibold text-slate-800 dark:text-slate-100 mb-3">No resumes yet</h2>
+              <p className="text-slate-600 dark:text-slate-300 mb-6">Create your first resume to get started</p>
+              <Link
+                href="/"
+                className="inline-flex items-center rounded-lg bg-sky-600 px-5 py-2 text-sm font-semibold text-white transition hover:bg-sky-700 focus:outline-none focus:ring-2 focus:ring-sky-400"
+              >
+                Create First Resume
+              </Link>
+            </section>
+          ) : (
+            <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+              {resumes.map((resume) => (
+                <Link
+                  key={resume.id}
+                  href={`/?id=${resume.id}`}
+                  className="block bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-xl shadow-lg p-6 transition hover:shadow-xl hover:border-sky-400"
+                >
+                  <h3 className="text-xl font-semibold text-slate-900 dark:text-slate-50 mb-2">
+                    {resume.title}
+                  </h3>
+                  <div className="text-sm text-slate-600 dark:text-slate-300 mb-4">
+                    <p className="truncate">{resume.name}</p>
+                    <p className="truncate">{resume.email}</p>
+                  </div>
+                  <div className="flex items-center justify-between text-xs text-slate-500 dark:text-slate-400">
+                    <span>
+                      Created: {new Date(resume.createdAt).toLocaleDateString()}
+                    </span>
+                    <span className="text-sky-600 dark:text-sky-400 font-medium">
+                      Edit →
+                    </span>
+                  </div>
+                </Link>
+              ))}
+            </div>
+          )}
+        </SignedIn>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/db/resume.ts
+++ b/src/lib/db/resume.ts
@@ -1,15 +1,35 @@
 import { db, schema } from './index';
 import { eq } from 'drizzle-orm';
 
+export type WorkHistoryEntry = {
+  companyName: string;
+  role: string;
+  dateOfWork: string;
+  description: string;
+};
+
+export type ProjectEntry = {
+  projectName: string;
+  projectUrl?: string;
+  projectDescription: string;
+};
+
+export type AchievementEntry = {
+  achievementName: string;
+  achievementUrl?: string;
+  achievementDescription: string;
+};
+
 export type NewResumePayload = {
   userId: string;
+  title: string;
   name: string;
   email: string;
   github?: string;
   description?: string;
-  workHistory: string[];
-  projects: string[];
-  achievements: string[];
+  workHistory: WorkHistoryEntry[];
+  projects: ProjectEntry[];
+  achievements: AchievementEntry[];
 };
 
 export async function createResume(data: NewResumePayload) {
@@ -17,6 +37,7 @@ export async function createResume(data: NewResumePayload) {
     .insert(schema.resumes)
     .values({
       userId: data.userId,
+      title: data.title,
       name: data.name,
       email: data.email,
       github: data.github,
@@ -26,14 +47,30 @@ export async function createResume(data: NewResumePayload) {
 
   const resumeId = resume.id;
 
-  const insertWork = data.workHistory.map((content) =>
-    db.insert(schema.workHistory).values({ resumeId, content })
+  const insertWork = data.workHistory.map((entry) =>
+    db.insert(schema.workHistory).values({
+      resumeId,
+      companyName: entry.companyName,
+      role: entry.role,
+      dateOfWork: entry.dateOfWork,
+      description: entry.description,
+    })
   );
-  const insertProjects = data.projects.map((content) =>
-    db.insert(schema.projects).values({ resumeId, content })
+  const insertProjects = data.projects.map((entry) =>
+    db.insert(schema.projects).values({
+      resumeId,
+      projectName: entry.projectName,
+      projectUrl: entry.projectUrl,
+      projectDescription: entry.projectDescription,
+    })
   );
-  const insertAchievements = data.achievements.map((content) =>
-    db.insert(schema.achievements).values({ resumeId, content })
+  const insertAchievements = data.achievements.map((entry) =>
+    db.insert(schema.achievements).values({
+      resumeId,
+      achievementName: entry.achievementName,
+      achievementUrl: entry.achievementUrl,
+      achievementDescription: entry.achievementDescription,
+    })
   );
 
   await Promise.all([...insertWork, ...insertProjects, ...insertAchievements]);
@@ -53,9 +90,22 @@ export async function getResume(id: string) {
 
   return {
     ...resume,
-    workHistory: work.map((w) => w.content),
-    projects: proj.map((p) => p.content),
-    achievements: ach.map((a) => a.content),
+    workHistory: work.map((w) => ({
+      companyName: w.companyName,
+      role: w.role,
+      dateOfWork: w.dateOfWork,
+      description: w.description,
+    })),
+    projects: proj.map((p) => ({
+      projectName: p.projectName,
+      projectUrl: p.projectUrl,
+      projectDescription: p.projectDescription,
+    })),
+    achievements: ach.map((a) => ({
+      achievementName: a.achievementName,
+      achievementUrl: a.achievementUrl,
+      achievementDescription: a.achievementDescription,
+    })),
   };
 }
 

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -3,6 +3,7 @@ import { pgTable, text, timestamp, uuid } from 'drizzle-orm/pg-core';
 export const resumes = pgTable('resumes', {
   id: uuid('id').primaryKey().defaultRandom(),
   userId: text('user_id').notNull(),
+  title: text('title').notNull(),
   name: text('name').notNull(),
   email: text('email').notNull(),
   github: text('github'),
@@ -14,20 +15,30 @@ export const resumes = pgTable('resumes', {
 export const workHistory = pgTable('work_history', {
   id: uuid('id').primaryKey().defaultRandom(),
   resumeId: uuid('resume_id').references(() => resumes.id, { onDelete: 'cascade' }),
-  content: text('content').notNull(),
+  content: text('content'),
+  companyName: text('company_name').notNull(),
+  role: text('role').notNull(),
+  dateOfWork: text('date_of_work').notNull(),
+  description: text('description').notNull(),
   createdAt: timestamp('created_at').defaultNow(),
 });
 
 export const projects = pgTable('projects', {
   id: uuid('id').primaryKey().defaultRandom(),
   resumeId: uuid('resume_id').references(() => resumes.id, { onDelete: 'cascade' }),
-  content: text('content').notNull(),
+  content: text('content'),
+  projectName: text('project_name').notNull(),
+  projectUrl: text('project_url'),
+  projectDescription: text('project_description').notNull(),
   createdAt: timestamp('created_at').defaultNow(),
 });
 
 export const achievements = pgTable('achievements', {
   id: uuid('id').primaryKey().defaultRandom(),
   resumeId: uuid('resume_id').references(() => resumes.id, { onDelete: 'cascade' }),
-  content: text('content').notNull(),
+  content: text('content'),
+  achievementName: text('achievement_name').notNull(),
+  achievementUrl: text('achievement_url'),
+  achievementDescription: text('achievement_description').notNull(),
   createdAt: timestamp('created_at').defaultNow(),
 });

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,25 @@
+import { clerkMiddleware, createRouteMatcher } from '@clerk/nextjs/server';
+
+// Define public routes that don't require authentication
+const isPublicRoute = createRouteMatcher([
+  '/',
+  '/sign-in(.*)',
+  '/sign-up(.*)',
+  '/api/webhooks(.*)',
+]);
+
+export default clerkMiddleware((auth, request) => {
+  // Protect all routes except public ones
+  if (!isPublicRoute(request)) {
+    auth().protect();
+  }
+});
+
+export const config = {
+  matcher: [
+    // Skip Next.js internals and all static files, unless found in search params
+    '/((?!_next|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest)).*)',
+    // Always run for API routes
+    '/(api|trpc)(.*)',
+  ],
+};


### PR DESCRIPTION
Add structured validation for resume nested data include title in
the schema and persistence.

- introduce workHistorySchema, projectSchema and achievementSchema in
  API route to validate nested objects instead of plain strings; this
  improves input correctness and makes downstream data shape explicit.
- require and persist resume title (z.string().min(1) + DB column and
  included when creating a resume) so resumes have a user-visible label.
- change auth calls to await auth() in POST and GET handlers to ensure
  proper async auth resolution.
- change GET list behavior to return up to 50 items and rename response
  key from items to resumes for clearer API semantics.
- adjust POST to persist title and keep optional github/description
  handling consistent.

Add a database cleanup script to identify and optionally drop tables
not defined in the application schema.

- scripts/cleanup-database.ts lists public tables, marks expected and
  system tables, prints untracked tables, and supports a --drop flag to
  remove them safely.
- include safety checks for POSTGRES_URL and prints helpful CLI
  instructions.

DB schema update

- add title column to resumes table definition to match validation and
  persistence changes.

These changes enforce stronger input validation, make resume resources
more discoverable via title, expand list limits, and provide a tool to
keep the database schema clean.